### PR TITLE
Allow party pack to subscribe to any number of topics

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -11,7 +11,7 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-func reply(ctx context.Context, m model.Message, rdb *redis.Client, reply string) {
+func reply(ctx context.Context, m model.Message, rdb *redis.Client, topic, reply string) {
 	if !strings.HasPrefix(m.To, "#") { // DMs go back to source, channel goes back to channel
 		m.To = m.From
 	}
@@ -21,11 +21,22 @@ func reply(ctx context.Context, m model.Message, rdb *redis.Client, reply string
 	m.Content = reply
 	m.Metadata.ID = uuid.Must(uuid.NewV4(), *new(error))
 	stringMsg, _ := json.Marshal(m)
-	rdb.Publish(ctx, *outbound, stringMsg)
+	rdb.Publish(ctx, topic, stringMsg)
 
 	log.Debug().
 		RawJSON("message", stringMsg).
 		Msg("Reply")
 
 	return
+}
+
+type stringArrayFlags []string
+
+func (i *stringArrayFlags) String() string {
+	return "String array flag"
+}
+
+func (i *stringArrayFlags) Set(s string) error {
+	*i = append(*i, s)
+	return nil
 }


### PR DESCRIPTION
This patch refactors the message listener structure to allow for an
arbitrary number of topic subscriptions and destinations.
